### PR TITLE
Pep8 cleanup 

### DIFF
--- a/fornax.py
+++ b/fornax.py
@@ -1,15 +1,8 @@
-
 import os
 import requests
 import json
-import warnings
 import logging
 import threading
-
-logging.basicConfig(level=logging.INFO,
-    format="%(asctime)s | %(name)s | %(message)s")
-log = logging.getLogger('fornax')
-
 
 from astropy.utils.data import download_file
 from astropy.utils.console import ProgressBarOrSpinner
@@ -17,26 +10,31 @@ from astropy.utils.console import ProgressBarOrSpinner
 import boto3
 import botocore
 
-from botocore.client import Config
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(name)s | %(message)s")
+log = logging.getLogger('fornax')
+
+
+__all__ = ['get_data_product', 'DataHandler', 'AWSDataHandler', 'AWSDataHandlerError']
 
 
 def get_data_product(product, provider='on-prem', access_url_column='access_url', **kwargs):
     """Top layer function to handle cloud/non-cloud access
-    
+
     Parameters
     ----------
-    product : astropy.table.Row 
+    product : astropy.table.Row
         The data url is accessed in product[access_url_column]
     provider : str
         Data provider to use. Options are: on-prem | aws
     access_url_column : str
-        The name of the column that contains the access url. 
-        This is typically the column with ucd 'VOX:Image_AccessReference' 
+        The name of the column that contains the access url.
+        This is typically the column with ucd 'VOX:Image_AccessReference'
         in SIA.
-        
+
     kwargs: other arguments to be passed to DataHandler or its subclasses
     """
-    
+
     handler = None
     if provider == 'on-prem':
         handler = DataHandler(product, access_url_column)
@@ -44,7 +42,7 @@ def get_data_product(product, provider='on-prem', access_url_column='access_url'
         handler = AWSDataHandler(product, access_url_column, **kwargs)
     else:
         raise Exception(f'Unable to handle provider {provider}')
-        
+
     handler._summary()
 
 
@@ -57,7 +55,6 @@ class DataHandler:
 
     """
 
-
     def __init__(self, product, access_url_column='access_url'):
         """Create a DataProvider object.
 
@@ -66,15 +63,14 @@ class DataHandler:
         product : astropy.table.Row
             The data url is accessed in product[access_url_column]
         access_url_column : str
-            The name of the column that contains the access url. 
-            This is typically the column with ucd 'VOX:Image_AccessReference' 
+            The name of the column that contains the access url.
+            This is typically the column with ucd 'VOX:Image_AccessReference'
             in SIA.
 
         """
         self.product = product
         self.access_url = product[access_url_column]
         self.processed_info = None
-
 
     def process_data_info(self):
         """Process data product info """
@@ -85,23 +81,21 @@ class DataHandler:
         log.info(self.processed_info['message'])
         return self.processed_info
 
-    
     def _summary(self):
         """A str representation of the data handler"""
         info = self.process_data_info()
         print('\n---- Summary ----')
-        for k,v in info.items():
-            print(f'{k:12}: {v}')
+        for key, value in info.items():
+            print(f'{key:12}: {value}')
         print('-----------------\n')
-
 
     def download(self):
         """Download data. Can be overloaded with different implimentation"""
         info = self.process_data_info()
         return download_file(info['access_url'])
 
-    
-class AWSDataHandlerException(Exception):
+
+class AWSDataHandlerError(Exception):
     pass
 
 
@@ -110,21 +104,21 @@ class AWSDataHandler(DataHandler):
 
     def __init__(self, product, access_url_column='access_url', profile=None, requester_pays=False):
         """Handle AWS-specific authentication and data download
-        
+
         Requires boto3
 
         Parameters
         ----------
-        product : astropy.table.Row. 
-            aws-s3 information should be available in product['cloud_access'], 
+        product : astropy.table.Row.
+            aws-s3 information should be available in product['cloud_access'],
             otherwise, fall back to on-prem using product[access_url_column]
         access_url_column : str
-            The name of the column that contains the access url for on-prem 
-            access fall back. This is typically the column with ucd 
+            The name of the column that contains the access url for on-prem
+            access fall back. This is typically the column with ucd
             'VOX:Image_AccessReference' in SIA.
         profile : str
             name of the user's profile for credentials in ~/.aws/config
-            or ~/.aws/credentials. Use to authenticate the AWS user with 
+            or ~/.aws/credentials. Use to authenticate the AWS user with
             boto3 when needed.
         requester_pays : bool
             Used when the data has region-restricted access and the user
@@ -132,9 +126,9 @@ class AWSDataHandler(DataHandler):
             authentication using a profile.
 
         """
-        
+
         if requester_pays:
-            raise NotImplemented('requester_pays is not implemented.')
+            raise NotImplementedError('requester_pays is not implemented.')
 
         super().__init__(product, access_url_column)
 
@@ -143,12 +137,10 @@ class AWSDataHandler(DataHandler):
         self.profile = profile
         self.product = product
 
-
-
     def _validate_aws_info(self, info):
-        """Do some basic validation of the json information provided in the 
+        """Do some basic validation of the json information provided in the
         data product's cloud_access column.
-    
+
         Parameters
         ----------
         info : dict
@@ -168,72 +160,65 @@ class AWSDataHandler(DataHandler):
         assert('bucket' in keys)
         assert('path' in keys)
 
-
         if info['path'][0] == '/':
             info['path'] = info['path'][1:]
 
         return info
 
-
-
     def process_data_info(self):
         """Process cloud infromation from data product metadata
-        
+
         This returns a dict which contains information on how to access
         the data. The main logic that attempts to interpret the cloud_access
         column provided for the data product. If sucessfully processed, the
         access details (bucket, path etc) are added to the final dictionary.
         If any information is missing, the returned dict will return access_url
-        that allows points to the data location in the on-prem servers as 
+        that allows points to the data location in the on-prem servers as
         a backup.
-        
+
         """
-        
+
         if self.processed_info is not None:
             return self.processed_info
-        
-        
+
         # Get a default on-prem-related information
         info = {
-            'access_url': self.access_url, 
-            'message'   : 'Accessing data from on-prem servers.'
+            'access_url': self.access_url,
+            'message': 'Accessing data from on-prem servers.'
         }
 
         try:
             # do we have cloud_access info in the data product?
-            if not 'cloud_access' in self.product.keys():
+            if 'cloud_access' not in self.product.keys():
                 msg = 'Input product does not have any cloud access information.'
-                raise AWSDataHandlerException(msg)
-                
+                raise AWSDataHandlerError(msg)
+
             # read json provided by the archive server
             cloud_access = json.loads(self.product['cloud_access'])
 
             # do we have information specific to aws in the data product?
-            if not 'aws' in cloud_access:
-                msg  = 'No aws cloud access information in the data product.'
-                raise AWSDataHandlerException(msg)
-                
-            
+            if 'aws' not in cloud_access:
+                msg = 'No aws cloud access information in the data product.'
+                raise AWSDataHandlerError(msg)
+
             # we have info about data in aws; validate it first #
             # TODO: add support for multiple aws access points. This may be useful
             aws_info = cloud_access['aws']
             try:
                 aws_info = self._validate_aws_info(aws_info)
             except Exception as e:
-                raise AWSDataHandlerException(str(e))
-            
+                raise AWSDataHandlerError(str(e))
+
             data_region = aws_info['region']
-            data_access = aws_info['access'] # open | region | none
+            data_access = aws_info['access']  # open | region | none
             log.info(f'data region: {data_region}')
             log.info(f'data access mode: {data_access}')
-            
-            
+
             # data on aws not accessible for some reason
             if data_access == 'none':
                 msg = 'Data access mode is "none".'
-                raise AWSDataHandlerException(msg)
-            
-            
+                raise AWSDataHandlerError(msg)
+
             # data have open access
             if data_access == 'open':
                 s3_config = botocore.client.Config(signature_version=botocore.UNSIGNED)
@@ -241,20 +226,20 @@ class AWSDataHandler(DataHandler):
                 accessible, message = self.is_accessible(s3_resource, aws_info['bucket'], aws_info['path'])
                 msg = 'Accessing public data anonymously on aws ... '
                 if not accessible:
-                    msg  = f'{msg}  {message}'
-                    raise AWSDataHandlerException(msg)
-                
+                    msg = f'{msg}  {message}'
+                    raise AWSDataHandlerError(msg)
+
             elif data_access == 'region':
-                
+
                 accessible = False
                 messages = []
                 while not accessible:
 
-                    ## -----------------------
-                    ## NOTE: THIS MAY NEED TO BE COMMENTED OUT BECAUSE IT MAY NOT BE POSSIBLE 
-                    ## TO ACCESS REGION-RESTRICTED DATA ANONYMOUSLY.
-                    ## -----------------------
-                    # Attempting anonymous access: 
+                    # -----------------------
+                    # NOTE: THIS MAY NEED TO BE COMMENTED OUT BECAUSE IT MAY NOT BE POSSIBLE
+                    # TO ACCESS REGION-RESTRICTED DATA ANONYMOUSLY.
+                    # -----------------------
+                    # Attempting anonymous access:
                     msg = 'Accessing region data anonymously ...'
                     s3_config = botocore.client.Config(signature_version=botocore.UNSIGNED)
                     s3_resource = boto3.resource(service_name='s3', config=s3_config)
@@ -263,25 +248,23 @@ class AWSDataHandler(DataHandler):
                         break
                     message = f'  - {msg} {message}.'
                     messages.append(message)
-                        
-                        
+
                     # If profile is given, try to use it first as it takes precedence.
                     if self.profile is not None:
                         msg = f'Accessing data using profile: {self.profile} ...'
                         try:
-                            s3_session  = boto3.session.Session(profile_name=self.profile)
+                            s3_session = boto3.session.Session(profile_name=self.profile)
                             s3_resource = s3_session.resource(service_name='s3')
                             accessible, message = self.is_accessible(s3_resource, aws_info['bucket'], aws_info['path'])
                             if accessible:
                                 break
                             else:
-                                raise AWSDataHandlerException(message)
+                                raise AWSDataHandlerError(message)
                         except Exception as e:
                             message = f'  - {msg} {str(e)}.'
                         messages.append(message)
-                    
-                    
-                    # If access with profile fails, attemp to use any credientials 
+
+                    # If access with profile fails, attemp to use any credientials
                     # in the user system e.g. environment variables etc. boto3 should find them.
                     msg = 'Accessing region data with other credentials ...'
                     s3_resource = boto3.resource(service_name='s3')
@@ -290,37 +273,32 @@ class AWSDataHandler(DataHandler):
                         break
                     message = f'  - {msg} {message}.'
                     messages.append(message)
-                    
-                    
+
                     # if we are here, then we cannot access the data. Fall back to on-prem
-                    msg  = '\nUnable to authenticate or access data with "region" access mode:\n'
+                    msg = '\nUnable to authenticate or access data with "region" access mode:\n'
                     msg += '\n'.join(messages)
-                    raise AWSDataHandlerException(msg)
-            
+                    raise AWSDataHandlerError(msg)
             else:
-                msg = f'Unknown data access mode: {data_acess}.'
-                raise AWSDataHandlerException(msg)
-            
-            
+                msg = f'Unknown data access mode: {data_access}.'
+                raise AWSDataHandlerError(msg)
+
             # if we make it here, we have valid aws access information.
-            info['s3_path']   = aws_info['path']
+            info['s3_path'] = aws_info['path']
             info['s3_bucket'] = aws_info['bucket']
-            info['message']   = msg
-            info['s3_resource'] = s3_resource   
+            info['message'] = msg
+            info['s3_resource'] = s3_resource
             info['data_region'] = data_region
-            info['data_access'] = data_access       
-                            
-        except AWSDataHandlerException as e:
+            info['data_access'] = data_access
+
+        except AWSDataHandlerError as e:
             info['message'] += str(e)
-        
-        
+
         self.processed_info = info
         return self.processed_info
 
-
     def is_accessible(self, s3_resource, bucket_name, path):
         """Do a head_object call to test access
-        
+
         Paramters
         ---------
         s3_resource : s3.ServiceResource
@@ -329,13 +307,13 @@ class AWSDataHandler(DataHandler):
             bucket name.
         path : str
             path to file to test.
-            
+
         Return
         -----
         (accessible, msg) where accessible is a bool and msg is the failure message
-        
+
         """
-        
+
         s3_client = s3_resource.meta.client
 
         try:
@@ -344,10 +322,8 @@ class AWSDataHandler(DataHandler):
         except Exception as e:
             accessible = False
             msg = str(e)
-            
+
         return accessible, msg
-        
-    
 
     def download(self, **kwargs):
         """Download data, from aws if possible, else from on-prem"""
@@ -362,7 +338,6 @@ class AWSDataHandler(DataHandler):
             log.info('--- Downloading data from On-prem ---')
             download_file(data_info['access_url'])
 
-
     def length_file_s3(self):
         """
         Gets info from s3 and prints the file length or exception.
@@ -371,7 +346,7 @@ class AWSDataHandler(DataHandler):
 
         s3 = data_info.get('s3_resource', None)
         if not s3:
-            print(f'Checking length: No AWS info available')
+            print('Checking length: No AWS info available')
             return
 
         s3_client = s3.meta.client
@@ -392,8 +367,6 @@ class AWSDataHandler(DataHandler):
             length = 0
 
         print(f'Checking length: {bucket_path=}, {ex=}, {length=}')
-
-
 
     # adapted from astroquery.mast.
     def _download_file_s3(self, data_info, local_path=None, cache=True):
@@ -419,7 +392,7 @@ class AWSDataHandler(DataHandler):
         if not bucket_path:
             raise Exception(f"Unable to locate file {bucket_path}.")
 
-        ## TODO: handle this in a better way
+        # TODO: handle this in a better way
         if local_path is None:
             local_path = bucket_path.strip('/').split('/')[-1]
 
@@ -463,9 +436,6 @@ class AWSDataHandler(DataHandler):
 
             bkt.download_file(bucket_path, local_path, Callback=progress_callback)
 
-
-
-
     def user_on_aws(self):
         """Check if the user is in on aws
         the following works for aws, but it is not robust enough
@@ -475,9 +445,8 @@ class AWSDataHandler(DataHandler):
 
         """
         uuid = '/sys/hypervisor/uuid'
-        is_aws =  os.path.exists(uuid) or 'AWS_REGION' in os.environ
+        is_aws = os.path.exists(uuid) or 'AWS_REGION' in os.environ
         return True  # is_aws
-
 
     def user_region(self):
         """Find region of the user in an ec2 instance.
@@ -504,5 +473,3 @@ class AWSDataHandler(DataHandler):
             region = response.json()['region']
 
         return region
-
-


### PR DESCRIPTION
I was running the linter to get rid of most of my editor warnings. Some of these were a tiny bit more than stylistic, e.g. I added a namespace cleanup via `__all__`, as well as renamed the custom exception.


 (running flake8 fornax.py --count --stat --max-line-length=120), leaving placeholders unfixed