### PR TITLE
returning the handler to be able to download the data itself

### DIFF
--- a/fornax.py
+++ b/fornax.py
@@ -18,7 +18,8 @@ log = logging.getLogger('fornax')
 __all__ = ['get_data_product', 'DataHandler', 'AWSDataHandler', 'AWSDataHandlerError']
 
 
-def get_data_product(product, provider='on-prem', access_url_column='access_url', **kwargs):
+def get_data_product(product, provider='on-prem', access_url_column='access_url',
+                     access_summary_only=False, verbose=True, **kwargs):
     """Top layer function to handle cloud/non-cloud access
 
     Parameters
@@ -43,7 +44,11 @@ def get_data_product(product, provider='on-prem', access_url_column='access_url'
     else:
         raise Exception(f'Unable to handle provider {provider}')
 
-    handler._summary()
+    if verbose:
+        handler._summary()
+
+    if not access_summary_only:
+        return handler
 
 
 class DataHandler:


### PR DESCRIPTION
Eventually, we need to be able to open/download the data products. This small PR exposes the already existing functionality, but ideally, there should be a way to keep it all in memory without saving the files (I'll open an issue for that aspect).