### PR TITLE
ENH: Adding s3_uri to the API

### DIFF
--- a/fornax.py
+++ b/fornax.py
@@ -141,6 +141,13 @@ class AWSDataHandler(DataHandler):
         self.requester_pays = requester_pays
         self.profile = profile
         self.product = product
+        self._s3_uri = None
+
+    @property
+    def s3_uri(self):
+        if not self._s3_uri:
+            self._s3_uri = f's3://{self.processed_info["s3_bucket"]}/{self.processed_info["s3_path"]}'
+        return self._s3_uri
 
     def _validate_aws_info(self, info):
         """Do some basic validation of the json information provided in the

--- a/fornax.py
+++ b/fornax.py
@@ -146,6 +146,7 @@ class AWSDataHandler(DataHandler):
     @property
     def s3_uri(self):
         if not self._s3_uri:
+            self.process_data_info()
             self._s3_uri = f's3://{self.processed_info["s3_bucket"]}/{self.processed_info["s3_path"]}'
         return self._s3_uri
 


### PR DESCRIPTION
This is to address https://github.com/fornax-navo/fornax-cloud-access-API/issues/9


Toy example to join the the usecase from the notebook here and the s3 astropy PR by the other fornax WG:

```
import fornax
import pyvo
import astropy.coordinates as coord
pos = coord.SkyCoord.from_name("ngc 4151")


query_url = 'https://mast.stsci.edu/portal_vo/Mashup/VoQuery.asmx/SiaV1?MISSION=HST&'
query_result = pyvo.dal.sia.search(query_url, pos=pos, size=0.0)
table_result = query_result.to_table()
col_name = query_result.fieldname_with_ucd('VOX:Image_AccessReference')
data_product = table_result[0]

handler = fornax.get_data_product(data_product, 'aws', access_url_column=col_name)
from astropy.io import fits
fits.open(handler.s3_uri)
```

resulting a lazy loaded hdulist rather than a downloaded fits file:

```<class 'astropy.io.fits.hdu.hdulist.HDUList'> (partially read)```





